### PR TITLE
Fixed landing page links for TheHive and Cortex

### DIFF
--- a/nginx/landing_page/index.html
+++ b/nginx/landing_page/index.html
@@ -122,7 +122,7 @@
 					<div class="clearfix visible-md-block visible-lg-block"></div>
 
 					<div class="col-md-4 col-sm-6 col-xs-6 col-xxs-12 text-center fh5co-work-item work-box">
-						<figure><a href="http://host-ip:9000"><img class="img-responsive" src="images/thehive.png" alt="TheHive" height="250" width="250"></a></figure>
+						<figure><a href="https://host-ip/thehive/index.html"><img class="img-responsive" src="images/thehive.png" alt="TheHive" height="250" width="250"></a></figure>
 						<p class="fh5co-category">TheHive </p>
 						<h3 class="heading"></h3>
 					</div>
@@ -130,7 +130,7 @@
 					<div class="clearfix visible-sm-block visible-xs-block"></div>
 
 					<div class="col-md-4 col-sm-6 col-xs-6 col-xxs-12 text-center fh5co-work-item work-box">
-						<figure><a href="http://host-ip:9001"><img class="img-responsive" src="images/cortex.png" alt="Cortex" height="250" width="250"></a></figure>
+						<figure><a href="https://host-ip/cortex/index.html"><img class="img-responsive" src="images/cortex.png" alt="Cortex" height="250" width="250"></a></figure>
 						<p class="fh5co-category">Cortex</p>
 						<h3 class="heading"></h3>
 					</div>


### PR DESCRIPTION
The landing page links for TheHive and Cortex do not appear to be consistent with [lines 60-61 of nginx/landing_page/index.html](https://github.com/capesstack/capes-docker/blob/d39fd1805bbacc394dc9ae6fabc06791be5bf8bb/nginx/landing_page/index.html#L60-L61), which makes the two services unreachable via the landing page in a standard deployment of CAPESstack using `deploy_capes.sh`. 